### PR TITLE
[Sync] Update project files from source repository (cd65317)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,7 +16,7 @@ trim_trailing_whitespace = false
 indent_style = space
 indent_size  = 2
 
-[*.json]
+[*.{json,prettierrc}]
 indent_style = space
 indent_size  = 4
 
@@ -35,5 +35,5 @@ indent_style = tab
 indent_style = space
 indent_size  = 2
 
-[{LICENSE,Dockerfile,.gitignore,.dockerignore}]
+[{LICENSE,Dockerfile,.gitignore,.dockerignore,.prettierignore}]
 insert_final_newline = true

--- a/.github/.env.base
+++ b/.github/.env.base
@@ -224,24 +224,23 @@ NANCY_VERSION=v1.0.51                  # https://github.com/sonatype-nexus-commu
 # 🪄 MAGE-X CONFIGURATION
 # ================================================================================================
 
-MAGE_X_VERSION=v1.4.0                  # https://github.com/mrz1836/mage-x/releases
+MAGE_X_VERSION=v1.6.0                                         # https://github.com/mrz1836/mage-x/releases
+MAGE_X_AUTO_DISCOVER_BUILD_TAGS=true                          # Enable auto-discovery of build tags
+MAGE_X_AUTO_DISCOVER_BUILD_TAGS_EXCLUDE=race,custom           # Comma-separated list of tags to exclude
+MAGE_X_FORMAT_EXCLUDE_PATHS=vendor,node_modules,.git,.idea    # Format exclusion paths (comma-separated directories to exclude from formatting)
+MAGE_X_GITLEAKS_VERSION=8.28.0                                # https://github.com/gitleaks/gitleaks/releases
+MAGE_X_GOFUMPT_VERSION=v0.8.0                                 # https://github.com/mvdan/gofumpt/releases
+MAGE_X_GOLANGCI_LINT_VERSION=v2.4.0                           # https://github.com/golangci/golangci-lint/releases
+MAGE_X_GORELEASER_VERSION=v2.12.0                             # https://github.com/goreleaser/goreleaser/releases
+MAGE_X_GOVULNCHECK_VERSION=v1.1.4                             # https://pkg.go.dev/golang.org/x/vuln
+MAGE_X_GO_SECONDARY_VERSION=1.24.x                            # Secondary Go version for MAGE-X (also our secondary)
+MAGE_X_GO_VERSION=1.24.x                                      # Primary Go version for MAGE-X (also our primary)
+MAGE_X_MOCKGEN_VERSION=v0.6.0                                 # https://github.com/uber-go/mock/releases
+MAGE_X_NANCY_VERSION=v1.0.51                                  # https://github.com/sonatype-nexus-community/nancy/releases
+MAGE_X_STATICCHECK_VERSION=2025.1.1                           # https://github.com/dominikh/go-tools/releases
+MAGE_X_SWAG_VERSION=v1.16.6                                   # https://github.com/swaggo/swag/releases
+MAGE_X_YAMLFMT_VERSION=v0.17.2                                # https://github.com/google/yamlfmt/releases
 
-# Format exclusion paths (comma-separated directories to exclude from formatting)
-MAGE_X_FORMAT_EXCLUDE_PATHS=vendor,node_modules,.git,.idea,.vscode
-MAGE_X_AUTO_DISCOVER_BUILD_TAGS=true                        # Enable auto-discovery of build tags
-MAGE_X_AUTO_DISCOVER_BUILD_TAGS_EXCLUDE=race,custom         # Comma-separated list of tags to exclude
-MAGE_X_GOLANGCI_LINT_VERSION=v2.4.0                         # https://github.com/golangci/golangci-lint/releases
-MAGE_X_GOFUMPT_VERSION=v0.8.0                               # https://github.com/mvdan/gofumpt/releases
-MAGE_X_GOVULNCHECK_VERSION=v1.1.4                           # https://pkg.go.dev/golang.org/x/vuln
-MAGE_X_MOCKGEN_VERSION=v0.6.0                               # https://github.com/uber-go/mock/releases
-MAGE_X_SWAG_VERSION=v1.16.6                                 # https://github.com/swaggo/swag/releases
-MAGE_X_STATICCHECK_VERSION=2025.1.1                         # https://github.com/dominikh/go-tools/releases
-MAGE_X_NANCY_VERSION=v1.0.51                                # https://github.com/sonatype-nexus-community/nancy/releases
-MAGE_X_GITLEAKS_VERSION=8.28.0                              # https://github.com/gitleaks/gitleaks/releases
-MAGE_X_GORELEASER_VERSION=v2.12.0                           # https://github.com/goreleaser/goreleaser/releases
-MAGE_X_YAMLFMT_VERSION=v0.17.2                              # https://github.com/google/yamlfmt/releases
-MAGE_X_GO_VERSION=1.24.x                                    # Primary Go version for MAGE-X (also our primary)
-MAGE_X_GO_SECONDARY_VERSION=1.24.x                          # Secondary Go version for MAGE-X (also our secondar
 # Runtime variables (set by setup-goreleaser action):
 # MAGE_X_GORELEASER_PATH - Path to installed goreleaser binary
 # MAGE_X_GORELEASER_INSTALLED - Set to 'true' when goreleaser is available

--- a/.github/tech-conventions/ci-validation.md
+++ b/.github/tech-conventions/ci-validation.md
@@ -25,7 +25,7 @@ Failing PRs will be blocked. AI agents should iterate until CI passes.
 1. **Code Quality Checks**
    - Format validation (gofmt, goimports, gofumpt)
    - Linting with 60+ linters via golangci-lint
-   - YAML formatting with yamlfmt
+   - YAML formatting with Prettier
 
 2. **Testing Suite**
    - Unit tests with coverage reporting

--- a/.github/tech-conventions/go-essentials.md
+++ b/.github/tech-conventions/go-essentials.md
@@ -385,27 +385,12 @@ platforms.
 
 <br><br>
 
-## 💄 yamlfmt (YAML Formatting)
+## 💄 YAML Formatting
 
-YAML files must be formatted consistently using yamlfmt to ensure clean diffs and readable configuration files.
+YAML files must be formatted consistently to ensure clean diffs and readable configuration files.
 
-**Local Setup:**
 ```bash
-# Install yamlfmt
-go install github.com/google/yamlfmt/cmd/yamlfmt@latest
+magex format:fix
 ```
 
-**Format YAML files:**
-```bash
-# Check and format YAML files
-yamlfmt .
-
-# Use with configuration file if available
-yamlfmt -conf .github/.yamlfmt .
-```
-
-**Configuration:**
-* EditorConfig rules are automatically applied for YAML formatting
-* Optional: `.github/.yamlfmt` configuration file for advanced settings
-
-> CI automatically validates YAML formatting using yamlfmt with EditorConfig integration. All YAML files must pass formatting checks before merge.
+> The `magex format:fix` command handles YAML formatting (via yamlfmt) along with Go, JSON, and other file types. CI automatically validates formatting using the same tools.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,5 @@
 {
-    "recommendations": ["golang.Go"]
+    "recommendations": [
+        "golang.Go"
+    ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,14 +1,14 @@
 {
-    "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch",
-            "type": "go",
-            "request": "launch",
-            "mode": "auto",
-            "program": "${fileDirname}",
+            "args": [],
             "env": {},
-            "args": []
+            "mode": "auto",
+            "name": "Launch",
+            "program": "${fileDirname}",
+            "request": "launch",
+            "type": "go"
         }
-    ]
+    ],
+    "version": "0.2.0"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,26 +1,28 @@
 {
-    "[go]": {
-        "editor.formatOnSave": true,
-        "editor.codeActionsOnSave": {
-            "source.organizeImports": "explicit"
-        }
-    },
     "[go.mod]": {
-        "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
             "source.organizeImports": "explicit"
-        }
+        },
+        "editor.formatOnSave": true
     },
-    "go.useLanguageServer": true,
-    "gopls": {
-        "formatting.local": "github.com/mrz1836/mage-x",
-        "formatting.gofumpt": true
+    "[go]": {
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": "explicit"
+        },
+        "editor.formatOnSave": true
     },
-    "go.lintTool": "golangci-lint",
-    "go.lintFlags": ["--verbose"],
     "[go][go.mod]": {
         "editor.codeActionsOnSave": {
             "source.organizeImports": "explicit"
         }
+    },
+    "go.lintFlags": [
+        "--verbose"
+    ],
+    "go.lintTool": "golangci-lint",
+    "go.useLanguageServer": true,
+    "gopls": {
+        "formatting.gofumpt": true,
+        "formatting.local": "github.com/mrz1836/mage-x"
     }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,15 +1,17 @@
 {
-    "version": "2.0.0",
     "tasks": [
         {
-            "label": "magex",
-            "type": "shell",
             "command": "magex",
-            "problemMatcher": ["$go"],
             "group": {
-                "kind": "build",
-                "isDefault": true
-            }
+                "isDefault": true,
+                "kind": "build"
+            },
+            "label": "magex",
+            "problemMatcher": [
+                "$go"
+            ],
+            "type": "shell"
         }
-    ]
+    ],
+    "version": "2.0.0"
 }


### PR DESCRIPTION
## What Changed
* Updated 2 individual file(s) to synchronize with the source repository
* Synchronized 6 file(s) from directory mappings
* Applied file transformations and updates based on sync configuration
* Brought target repository in line with source repository state at commit b0edbc3

## Directory Synchronization Details
The following directories were synchronized:

### `.github/tech-conventions` → `.github/tech-conventions`

### `.github/ISSUE_TEMPLATE` → `.github/ISSUE_TEMPLATE`

### `.vscode` → `.vscode`

## Performance Metrics
* **Files processed**: 22 (8 changed, 0 deleted, 14 skipped)
* **Files attempted to change**: 8 (go-broadcast processing)
* **File processing time**: 6519ms

## Why It Was Necessary
This synchronization ensures the target repository stays up-to-date with the latest changes from the configured source repository. The sync operation identifies and applies only the necessary file changes while maintaining consistency across repositories.

## Testing Performed
* Validated sync configuration and file mappings
* Verified file transformations applied correctly
* Confirmed no unintended changes were introduced
* All automated checks and linters passed

## Impact / Risk
* **Low Risk**: Standard sync operation with established patterns
* **No Breaking Changes**: File updates maintain backward compatibility
* **Performance**: No impact on application performance
* **Dependencies**: No dependency changes included in this sync

<!-- go-broadcast-metadata
group:
  id: mrz-tools
  name: mrz-tools
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: cd65317dbaad0871e3fb169d83190b99824f0a06
  target_repo: mrz1836/mage-x
  sync_commit: b0edbc338271a229de8528ffd050ab1f5ffc9c12
  sync_time: 2025-09-11T21:41:36-04:00
directories:
  - src: .github/tech-conventions
    dest: .github/tech-conventions
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
  - src: .vscode
    dest: .vscode
performance:
  total_files: 22
-->
