### PR TITLE
fix(update): prevent SIGBUS on Linux when replacing running binary

### DIFF
--- a/pkg/mage/update.go
+++ b/pkg/mage/update.go
@@ -737,6 +737,29 @@ func copyFile(src, dst string) error {
 	return nil
 }
 
+// installBinaryFallback copies src to dst via a temp file then atomically
+// renames it into place. This avoids truncating a running binary in-place on
+// Linux (which would corrupt its memory-map and raise SIGBUS).
+func installBinaryFallback(src, dst string) error {
+	tmpPath := dst + ".new"
+	if copyErr := copyFile(src, tmpPath); copyErr != nil {
+		if rmErr := os.Remove(tmpPath); rmErr != nil { // #nosec G703 -- tmpPath derived from validated dst
+			log.Printf("failed to remove temp binary: %v", rmErr)
+		}
+		return fmt.Errorf("failed to install binary: %w", copyErr)
+	}
+	if renErr := os.Rename(tmpPath, dst); renErr != nil { // #nosec G703 -- tmpPath/dst are from validated internal paths
+		if rmErr := os.Remove(tmpPath); rmErr != nil { // #nosec G703 -- tmpPath derived from validated dst
+			log.Printf("failed to remove temp binary: %v", rmErr)
+		}
+		return fmt.Errorf("failed to install binary: %w", renErr)
+	}
+	if removeErr := os.Remove(src); removeErr != nil { // #nosec G703 -- src is from internal download process
+		log.Printf("failed to remove temporary binary: %v", removeErr)
+	}
+	return nil
+}
+
 // installUpdate installs the downloaded update
 func installUpdate(info *UpdateInfo, updateDir string) error {
 	// Get GOPATH for installation location
@@ -805,14 +828,11 @@ func installUpdate(info *UpdateInfo, updateDir string) error {
 		return errMagexBinaryNotFound
 	}
 
-	// Move binary to final location
+	// Move binary to final location; fall back to copy+atomic-rename on
+	// cross-filesystem moves (e.g. /tmp → ~/go/bin).
 	if renameErr := os.Rename(binaryPath, outputPath); renameErr != nil { // #nosec G703 -- binaryPath/outputPath are from validated internal download
-		// Try copy + delete if rename fails (cross-filesystem moves)
-		if copyErr := copyFile(binaryPath, outputPath); copyErr != nil {
-			return fmt.Errorf("failed to install binary: %w", copyErr)
-		}
-		if removeErr := os.Remove(binaryPath); removeErr != nil { // #nosec G703 -- binaryPath is from internal download process
-			log.Printf("failed to remove temporary binary: %v", removeErr)
+		if err := installBinaryFallback(binaryPath, outputPath); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
## Problem

On Linux, `magex update:install` crashes with `Bus error (core dumped)` immediately after extracting the new binary.

**Root cause:** When the primary `os.Rename(binaryPath, outputPath)` fails (cross-filesystem move, e.g. `/tmp` → `~/go/bin`), the fallback called `copyFile(binaryPath, outputPath)` which uses `os.Create(outputPath)` — this **truncates the currently-executing binary in-place**. On Linux, the kernel memory-maps the ELF binary for execution; truncating it mid-run corrupts the mapping and raises SIGBUS. macOS handles this more gracefully, which is why the bug is Linux-only.

## Fix

Write the new binary to a temporary file (`outputPath + ".new"`) first, then atomically rename it into place:

```
tmp → copy → rename (atomic) → replace directory entry
```

The `rename(2)` syscall replaces the directory entry atomically without touching the old inode, so the kernel's existing mmap of the old file stays valid until the process exits naturally. This is the standard pattern for self-updating binaries on Linux/POSIX.

Cleanup of the temp file is attempted on any failure path.

## Testing

- All existing update tests pass (`go test -race -run TestUpdate ./pkg/mage/...`)
- Full build clean (`go build ./...`)

## Workaround (for users on current version)

```bash
go install github.com/mrz1836/mage-x/cmd/magex@latest
```