### PR TITLE
test: run docs GoDocs tests offline instead of hitting proxy.golang.org

### DIFF
--- a/pkg/mage/docs.go
+++ b/pkg/mage/docs.go
@@ -37,6 +37,11 @@ const (
 	versionDev = "dev"
 )
 
+// docsProxyBaseURL is the base URL of the Go module proxy used to trigger a
+// pkg.go.dev sync. It is a package-level variable so tests can point it at a
+// local server and avoid reaching the real proxy.golang.org over the network.
+var docsProxyBaseURL = "https://proxy.golang.org"
+
 // DocServer represents a documentation server configuration
 type DocServer struct {
 	Tool     string   // "pkgsite", "godoc", or "none"
@@ -107,7 +112,7 @@ func (Docs) GoDocs(args ...string) error {
 	}
 
 	// Construct pkg.go.dev URL
-	proxyURL := fmt.Sprintf("https://proxy.golang.org/%s/@v/%s.info", module, currentVersion)
+	proxyURL := fmt.Sprintf("%s/%s/@v/%s.info", docsProxyBaseURL, module, currentVersion)
 
 	utils.Info("Triggering sync for %s@%s", module, currentVersion)
 

--- a/pkg/mage/docs_coverage_test.go
+++ b/pkg/mage/docs_coverage_test.go
@@ -1,6 +1,8 @@
 package mage
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -169,6 +171,18 @@ func (ts *DocsCoverageTestSuite) TestDocsGenerateSuccess() {
 
 // TestDocsGoDocsExercise tests Docs.GoDocs exercises the code path
 func (ts *DocsCoverageTestSuite) TestDocsGoDocsExercise() {
+	// Point the module proxy at a local test server so this test never
+	// reaches the real proxy.golang.org over the network.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"Version":"v0.0.0","Time":"2024-01-01T00:00:00Z"}`))
+	}))
+	defer server.Close()
+
+	originalBaseURL := docsProxyBaseURL
+	docsProxyBaseURL = server.URL
+	defer func() { docsProxyBaseURL = originalBaseURL }()
+
 	err := ts.withMockRunner(func() error {
 		return ts.docs.GoDocs()
 	})

--- a/pkg/mage/docs_test.go
+++ b/pkg/mage/docs_test.go
@@ -2,6 +2,8 @@ package mage
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -69,10 +71,19 @@ func (ts *DocsTestSuite) TestDocsGoDocs() {
 	docs := Docs{}
 
 	ts.Run("GoDocsBasic", func() {
-		// This test may fail without network access or valid module
-		err := docs.GoDocs()
-		// Should either succeed or fail gracefully
-		ts.Require().True(err == nil || err != nil)
+		// Point the module proxy at a local test server so this test never
+		// reaches the real proxy.golang.org over the network.
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"Version":"v0.0.0","Time":"2024-01-01T00:00:00Z"}`))
+		}))
+		defer server.Close()
+
+		originalBaseURL := docsProxyBaseURL
+		docsProxyBaseURL = server.URL
+		defer func() { docsProxyBaseURL = originalBaseURL }()
+
+		ts.Require().NoError(docs.GoDocs())
 	})
 }
 


### PR DESCRIPTION
## What

`Docs.GoDocs` triggers a pkg.go.dev sync by issuing a real HTTP GET to `https://proxy.golang.org/<module>/@v/<version>.info`. Two tests — `TestDocsGoDocs` and `TestDocsGoDocsExercise` — called `GoDocs()` directly with no HTTP stub, so **every `mage test` run made a live request to the public proxy.** That makes the suite depend on network access and trips outbound-connection firewall prompts. `GoDocsBasic`'s assertion (`err == nil || err != nil`) was also a tautology.

## Change

- Add a package-level `docsProxyBaseURL` seam in `docs.go` (defaults to `https://proxy.golang.org`; production behavior unchanged).
- Point both tests at a local `httptest` server and assert real success.

## Verification

Runs fully offline:

```
GOPROXY=off go test ./pkg/mage/ -run 'TestDocsSuite/TestDocsGoDocs|TestDocsCoverageTestSuite/TestDocsGoDocsExercise' -count=1
ok  github.com/mrz1836/mage-x/pkg/mage
```

No production code path changes — only the proxy URL is now built from an overridable base.