### PR TITLE
feat(runner): configurable go build/run timeout via MAGE_X_BUILD_TIMEOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,10 @@ magex build:prebuild strategy=full p=8              # Traditional full build wit
 magex build:prebuild strategy=incremental batch=5 delay=100   # 100ms delay between batches
 magex build:prebuild strategy=mains-first mains-only=true     # Only build main packages
 magex build:prebuild exclude=test verbose=true                # Exclude test packages, verbose output
+
+# Raise the per-invocation build timeout for large cold-cache builds (default 5m).
+# Each batch is one `go build`; low parallelism (p=1) on a big module can exceed the default.
+MAGE_X_BUILD_TIMEOUT=15m magex build:prebuild strategy=incremental p=1
 ```
 
 </details>

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -441,7 +441,15 @@ export MAGE_X_BUILD_PLATFORM="linux/amd64"
 export MAGE_X_BUILD_CGO_ENABLED="false"
 export MAGE_X_BUILD_OUTPUT_DIR="dist"
 export MAGE_X_BUILD_BINARY="myapp"
+export MAGE_X_BUILD_TIMEOUT="5m"   # Per-invocation timeout for `go build`/`go run` (default 5m)
 ```
+
+> **`MAGE_X_BUILD_TIMEOUT`** caps how long a single `go build` (or `go run`) invocation
+> may run before it is canceled. It accepts any [Go duration string](https://pkg.go.dev/time#ParseDuration)
+> (e.g. `90s`, `10m`); invalid or empty values fall back to the 5-minute default.
+> Raise it when warming a cold build cache for a large dependency tree — for example
+> `magex build:prebuild` with low parallelism on a constrained CI runner, where a
+> single batch can otherwise exceed the default and be killed mid-compile.
 
 ### Test Variables
 ```bash

--- a/pkg/mage/constants.go
+++ b/pkg/mage/constants.go
@@ -182,6 +182,13 @@ const (
 	// DefaultFuzzWarmupTimeout is the timeout for pre-compiling fuzz test binaries
 	// with coverage instrumentation to warm the Go build cache before running individual tests.
 	DefaultFuzzWarmupTimeout = "5m"
+
+	// EnvBuildTimeout is the environment variable that overrides the per-invocation
+	// timeout for `go build` and `go run` commands. It accepts any Go duration
+	// string (e.g. "10m"); when unset or unparseable, DefaultGoBuildTimeout applies.
+	// This is primarily useful for cold-cache prebuilds of large dependency trees,
+	// which can exceed the default on constrained CI runners.
+	EnvBuildTimeout = "MAGE_X_BUILD_TIMEOUT"
 )
 
 // Coverage modes

--- a/pkg/mage/minimal_runner.go
+++ b/pkg/mage/minimal_runner.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mrz1836/mage-x/pkg/common/env"
 	"github.com/mrz1836/mage-x/pkg/common/providers"
 	"github.com/mrz1836/mage-x/pkg/exec"
 	"github.com/mrz1836/mage-x/pkg/mage/runtimectx"
@@ -16,6 +17,12 @@ import (
 var (
 	errRunnerNil = errors.New("runner cannot be nil")
 )
+
+// DefaultGoBuildTimeout is the fallback per-invocation timeout for `go build`
+// and `go run` when MAGE_X_BUILD_TIMEOUT is unset or cannot be parsed. It matches
+// the allowance given to `go install`/`go get`/`go mod`, because a cold build
+// compiles the full dependency tree and is at least as expensive as those.
+const DefaultGoBuildTimeout = 5 * time.Minute
 
 // SecureCommandRunner provides a secure implementation of CommandRunner using pkg/exec
 type SecureCommandRunner struct {
@@ -44,7 +51,7 @@ func (r *SecureCommandRunner) RunCmd(name string, args ...string) error {
 	defer cancel()
 
 	err := r.executor.Execute(ctx, name, args...)
-	return wrapTimeoutError(err, CommandContext{Name: name, Timeout: timeout})
+	return wrapTimeoutError(err, ctx, CommandContext{Name: name, Timeout: timeout})
 }
 
 // RunCmdOutput executes a command and returns its output
@@ -56,7 +63,7 @@ func (r *SecureCommandRunner) RunCmdOutput(name string, args ...string) (string,
 	defer cancel()
 
 	output, err := r.executor.ExecuteOutput(ctx, name, args...)
-	return strings.TrimSpace(output), wrapTimeoutError(err, CommandContext{Name: name, Timeout: timeout})
+	return strings.TrimSpace(output), wrapTimeoutError(err, ctx, CommandContext{Name: name, Timeout: timeout})
 }
 
 // RunCmdInDir executes a command in the specified working directory.
@@ -68,7 +75,7 @@ func (r *SecureCommandRunner) RunCmdInDir(dir, name string, args ...string) erro
 	defer cancel()
 
 	err := r.executor.ExecuteInDir(ctx, dir, name, args...)
-	return wrapTimeoutError(err, CommandContext{Name: name, Dir: dir, Timeout: timeout})
+	return wrapTimeoutError(err, ctx, CommandContext{Name: name, Dir: dir, Timeout: timeout})
 }
 
 // RunCmdOutputInDir executes a command in the specified directory and returns output.
@@ -80,20 +87,20 @@ func (r *SecureCommandRunner) RunCmdOutputInDir(dir, name string, args ...string
 	defer cancel()
 
 	output, err := r.executor.ExecuteOutputInDir(ctx, dir, name, args...)
-	return strings.TrimSpace(output), wrapTimeoutError(err, CommandContext{Name: name, Dir: dir, Timeout: timeout})
+	return strings.TrimSpace(output), wrapTimeoutError(err, ctx, CommandContext{Name: name, Dir: dir, Timeout: timeout})
 }
 
 // RunCmdWithEnv executes a command with additional environment variables.
 // This is goroutine-safe unlike os.Setenv() - each command gets its own environment.
 // Use this for cross-compilation where GOOS/GOARCH need to be set per-command.
-func (r *SecureCommandRunner) RunCmdWithEnv(env []string, name string, args ...string) error {
+func (r *SecureCommandRunner) RunCmdWithEnv(envVars []string, name string, args ...string) error {
 	ctx := runtimectx.Context()
 	timeout := r.getCommandTimeout(name, args)
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	err := r.executor.ExecuteWithEnv(ctx, env, name, args...)
-	return wrapTimeoutError(err, CommandContext{Name: name, Timeout: timeout})
+	err := r.executor.ExecuteWithEnv(ctx, envVars, name, args...)
+	return wrapTimeoutError(err, ctx, CommandContext{Name: name, Timeout: timeout})
 }
 
 // getCommandTimeout returns appropriate timeout based on command type
@@ -125,8 +132,11 @@ func (r *SecureCommandRunner) getCommandTimeout(name string, args []string) time
 				// Allow 5 minutes for package operations
 				return 5 * time.Minute
 			case CmdGoBuild, "run":
-				// Allow 3 minutes for build operations
-				return 3 * time.Minute
+				// Build/run operations. The default is generous because a cold
+				// build (e.g. the build:prebuild cache-warming path) compiles the
+				// entire dependency tree; override with MAGE_X_BUILD_TIMEOUT when
+				// building large modules on constrained runners.
+				return env.GetDuration(EnvBuildTimeout, DefaultGoBuildTimeout)
 			case CmdGoVet, CmdGoList:
 				// Allow 1 minute for vet and list operations
 				return 1 * time.Minute
@@ -198,31 +208,68 @@ type CommandContext struct {
 
 // wrapTimeoutError wraps context timeout/cancellation errors with descriptive messages.
 // Returns the original error unchanged if it's not a timeout or cancellation error.
-func wrapTimeoutError(err error, ctx CommandContext) error {
+//
+// A context deadline can surface in two different ways depending on how the child
+// process terminates:
+//
+//  1. Directly — the executor returns an error that wraps context.DeadlineExceeded.
+//  2. Indirectly — the graceful-cancel path signals the child (SIGINT) and the
+//     process exits with "signal: interrupt", which does NOT wrap
+//     context.DeadlineExceeded. In that case only the run context reflects the
+//     deadline, so we inspect runCtx.Err() as well.
+//
+// Checking runCtx.Err() catches case (2), so a timed-out command is reported as a
+// timeout instead of a cryptic "signal: interrupt".
+func wrapTimeoutError(err error, runCtx context.Context, cmdCtx CommandContext) error {
 	if err == nil {
 		return nil
 	}
 
-	if errors.Is(err, context.DeadlineExceeded) {
-		if ctx.Dir != "" {
-			return fmt.Errorf("command '%s' in '%s' exceeded timeout of %s: %w",
-				ctx.Name, ctx.Dir, ctx.Timeout, err)
-		}
-		return fmt.Errorf("command '%s' exceeded timeout of %s (context deadline exceeded): %w",
-			ctx.Name, ctx.Timeout, err)
+	ctxErr := runCtx.Err()
+
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctxErr, context.DeadlineExceeded) {
+		return formatTimeoutError(cmdCtx, ensureCause(err, context.DeadlineExceeded))
 	}
 
-	if errors.Is(err, context.Canceled) {
-		if ctx.Dir != "" {
-			return fmt.Errorf("command '%s' in '%s' was canceled: %w",
-				ctx.Name, ctx.Dir, err)
-		}
-		return fmt.Errorf("command '%s' was canceled after %s: %w",
-			ctx.Name, ctx.Timeout, err)
+	if errors.Is(err, context.Canceled) || errors.Is(ctxErr, context.Canceled) {
+		return formatCanceledError(cmdCtx, ensureCause(err, context.Canceled))
 	}
 
 	// Return err unchanged if not a timeout/cancellation - it already has context from exec layer
 	return err
+}
+
+// ensureCause guarantees the returned error unwraps to sentinel while preserving
+// the original error's message. When err already wraps sentinel it is returned
+// unchanged; otherwise sentinel is wrapped with err's text appended. The latter
+// happens when a deadline is only observable via the run context because the child
+// was terminated by a signal (e.g. "signal: interrupt") rather than returning the
+// context error itself.
+func ensureCause(err, sentinel error) error {
+	if errors.Is(err, sentinel) {
+		return err
+	}
+	return fmt.Errorf("%w (%w)", sentinel, err)
+}
+
+// formatTimeoutError renders a descriptive timeout error for the given command.
+func formatTimeoutError(cmdCtx CommandContext, cause error) error {
+	if cmdCtx.Dir != "" {
+		return fmt.Errorf("command '%s' in '%s' exceeded timeout of %s: %w",
+			cmdCtx.Name, cmdCtx.Dir, cmdCtx.Timeout, cause)
+	}
+	return fmt.Errorf("command '%s' exceeded timeout of %s (context deadline exceeded): %w",
+		cmdCtx.Name, cmdCtx.Timeout, cause)
+}
+
+// formatCanceledError renders a descriptive cancellation error for the given command.
+func formatCanceledError(cmdCtx CommandContext, cause error) error {
+	if cmdCtx.Dir != "" {
+		return fmt.Errorf("command '%s' in '%s' was canceled: %w",
+			cmdCtx.Name, cmdCtx.Dir, cause)
+	}
+	return fmt.Errorf("command '%s' was canceled after %s: %w",
+		cmdCtx.Name, cmdCtx.Timeout, cause)
 }
 
 // truncateString truncates a string to the specified length

--- a/pkg/mage/minimal_runner_test.go
+++ b/pkg/mage/minimal_runner_test.go
@@ -20,6 +20,9 @@ var (
 	errMinimalCommandOutputFailed = errors.New("command output failed")
 	errMinimalExecutionFailed     = errors.New("execution failed")
 	errMinimalOtherError          = errors.New("some other error")
+	// errMinimalSignalInterrupt mimics the error returned when the graceful-cancel
+	// path signals a child process; it does NOT wrap a context error.
+	errMinimalSignalInterrupt = errors.New("signal: interrupt")
 )
 
 // MinimalRunnerTestSuite defines the test suite for minimal runner functions
@@ -479,10 +482,16 @@ func TestSecureCommandRunner_getCommandTimeout(t *testing.T) {
 			expected: 5 * time.Minute,
 		},
 		{
-			name:     "go build gets 3 minutes",
+			name:     "go build gets default 5 minutes",
 			cmd:      "go",
 			args:     []string{"build", "./cmd/app"},
-			expected: 3 * time.Minute,
+			expected: DefaultGoBuildTimeout,
+		},
+		{
+			name:     "go run gets default 5 minutes",
+			cmd:      "go",
+			args:     []string{"run", "./cmd/app"},
+			expected: DefaultGoBuildTimeout,
 		},
 		{
 			name:     "go fmt gets 2 minutes",
@@ -641,6 +650,52 @@ func TestSecureCommandRunner_getCommandTimeout(t *testing.T) {
 	}
 }
 
+// TestSecureCommandRunner_getCommandTimeout_BuildTimeoutOverride verifies that
+// MAGE_X_BUILD_TIMEOUT overrides the default go build/run timeout and that
+// invalid values fall back to the default.
+func TestSecureCommandRunner_getCommandTimeout_BuildTimeoutOverride(t *testing.T) {
+	runner := &SecureCommandRunner{}
+
+	tests := []struct {
+		name     string
+		envValue string
+		args     []string
+		expected time.Duration
+	}{
+		{
+			name:     "override applies to go build",
+			envValue: "12m",
+			args:     []string{"build", "./..."},
+			expected: 12 * time.Minute,
+		},
+		{
+			name:     "override applies to go run",
+			envValue: "90s",
+			args:     []string{"run", "./cmd/app"},
+			expected: 90 * time.Second,
+		},
+		{
+			name:     "invalid value falls back to default",
+			envValue: "not-a-duration",
+			args:     []string{"build", "./..."},
+			expected: DefaultGoBuildTimeout,
+		},
+		{
+			name:     "empty value falls back to default",
+			envValue: "",
+			args:     []string{"build", "./..."},
+			expected: DefaultGoBuildTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(EnvBuildTimeout, tt.envValue)
+			assert.Equal(t, tt.expected, runner.getCommandTimeout("go", tt.args))
+		})
+	}
+}
+
 // TestSecureCommandRunner_ContextErrors tests context cancellation error messages
 func TestSecureCommandRunner_ContextErrors(t *testing.T) {
 	t.Run("context deadline exceeded provides clear error message", func(t *testing.T) {
@@ -721,11 +776,42 @@ func TestMinimalRunnerTestSuite(t *testing.T) {
 	suite.Run(t, new(MinimalRunnerTestSuite))
 }
 
+// runCtxState selects which run context a wrapTimeoutError test case exercises,
+// avoiding a context.Context field inside the table (see the containedctx linter).
+type runCtxState int
+
+const (
+	runCtxLive     runCtxState = iota // live context, Err() == nil
+	runCtxDeadline                    // deadline already elapsed, Err() == DeadlineExceeded
+	runCtxCanceled                    // explicitly canceled, Err() == Canceled
+)
+
+// newRunCtx builds a run context in the requested state. The returned cancel func
+// must be called by the caller to release resources.
+func newRunCtx(t *testing.T, state runCtxState) context.Context {
+	t.Helper()
+	switch state {
+	case runCtxDeadline:
+		ctx, cancel := context.WithDeadline(context.Background(), time.Unix(0, 0))
+		t.Cleanup(cancel)
+		return ctx
+	case runCtxCanceled:
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		return ctx
+	case runCtxLive:
+		fallthrough
+	default:
+		return context.Background()
+	}
+}
+
 // TestWrapTimeoutError tests the wrapTimeoutError helper function
 func TestWrapTimeoutError(t *testing.T) {
 	tests := []struct {
 		name           string
 		inputErr       error
+		runCtx         runCtxState
 		ctx            CommandContext
 		expectNil      bool
 		expectContains []string
@@ -795,11 +881,58 @@ func TestWrapTimeoutError(t *testing.T) {
 			},
 			expectErrorIs: context.DeadlineExceeded,
 		},
+		{
+			// Graceful-cancel path: the child is killed with SIGINT and returns
+			// "signal: interrupt" (not a context error). The deadline is only
+			// observable via the run context, so it must still read as a timeout.
+			name:     "signal interrupt with deadline context reported as timeout",
+			inputErr: errMinimalSignalInterrupt,
+			runCtx:   runCtxDeadline,
+			ctx:      CommandContext{Name: "go", Timeout: 3 * time.Minute},
+			expectContains: []string{
+				"go",
+				"exceeded timeout of 3m0s",
+				"signal: interrupt",
+			},
+			expectErrorIs: context.DeadlineExceeded,
+		},
+		{
+			name:     "signal interrupt with deadline context and dir",
+			inputErr: errMinimalSignalInterrupt,
+			runCtx:   runCtxDeadline,
+			ctx:      CommandContext{Name: "go", Dir: "/project", Timeout: 3 * time.Minute},
+			expectContains: []string{
+				"in '/project'",
+				"exceeded timeout of 3m0s",
+				"signal: interrupt",
+			},
+			expectErrorIs: context.DeadlineExceeded,
+		},
+		{
+			name:     "signal interrupt with canceled context reported as canceled",
+			inputErr: errMinimalSignalInterrupt,
+			runCtx:   runCtxCanceled,
+			ctx:      CommandContext{Name: "go", Timeout: 5 * time.Minute},
+			expectContains: []string{
+				"was canceled after 5m0s",
+				"signal: interrupt",
+			},
+			expectErrorIs: context.Canceled,
+		},
+		{
+			// A genuine command failure with a live context must NOT be relabeled
+			// as a timeout or cancellation.
+			name:           "real failure with live context passes through unchanged",
+			inputErr:       errMinimalOtherError,
+			runCtx:         runCtxLive,
+			ctx:            CommandContext{Name: "go", Timeout: 5 * time.Minute},
+			expectContains: []string{"some other error"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := wrapTimeoutError(tt.inputErr, tt.ctx)
+			result := wrapTimeoutError(tt.inputErr, newRunCtx(t, tt.runCtx), tt.ctx)
 
 			if tt.expectNil {
 				assert.NoError(t, result)
@@ -821,7 +954,7 @@ func TestWrapTimeoutError(t *testing.T) {
 // TestWrapTimeoutErrorPreservesOriginal verifies that errors.Is works correctly
 func TestWrapTimeoutErrorPreservesOriginal(t *testing.T) {
 	baseErr := context.DeadlineExceeded
-	wrappedErr := wrapTimeoutError(baseErr, CommandContext{
+	wrappedErr := wrapTimeoutError(baseErr, context.Background(), CommandContext{
 		Name:    "test-cmd",
 		Timeout: 5 * time.Minute,
 	})


### PR DESCRIPTION
## What Changed
- Made the per-invocation timeout for `go build` / `go run` configurable through a new `MAGE_X_BUILD_TIMEOUT` environment variable (any Go duration string, e.g. `10m`).
- Raised the default `go build`/`go run` timeout from **3m → 5m** (`DefaultGoBuildTimeout`), matching the allowance already given to `go install`/`go get`/`go mod`.
- Fixed timeout diagnostics: when the graceful-cancel path signals the child with SIGINT, the process exits with `signal: interrupt`, which does **not** wrap `context.DeadlineExceeded`. `wrapTimeoutError` now also inspects the run context, so a timed-out command is reported as a clear timeout (still `errors.Is(..., context.DeadlineExceeded)`) instead of a cryptic `signal: interrupt`.
- Added unit tests for the override, invalid/empty fallback, and both diagnostic paths; documented the knob in `README.md` and `docs/CONFIGURATION.md`.

## Why It Was Necessary
- The `go build` timeout was a hardcoded `3 * time.Minute` in `getCommandTimeout`, with no env/param/config override — unlike `golangci-lint` (reads `--timeout`) and `go test` (10m). `build:prebuild` is the cold-cache path by definition (it only runs on a build-cache miss), so it compiles the entire dependency tree; at low parallelism on constrained CI runners a single batch can exceed 3 minutes and get killed mid-compile.
- The failure surfaced only as `command failed [...]: signal: interrupt`, with no indication a timeout was responsible, making it hard to diagnose.

## Testing Performed
- `go build ./...` — clean
- `go vet ./...` — clean
- `golangci-lint run ./...` — 0 issues; `golangci-lint fmt --diff` — no changes
- `go test ./pkg/mage/... ./pkg/exec/... ./pkg/common/env/...` — all passing, including new cases:
  - `TestSecureCommandRunner_getCommandTimeout_BuildTimeoutOverride` (override / invalid / empty)
  - `go build`/`go run` default now `DefaultGoBuildTimeout`
  - `TestWrapTimeoutError` — SIGINT + deadline context reported as timeout; SIGINT + canceled context reported as canceled; real failure with a live context passes through unchanged

## Impact / Risk
- Low. Behavior is backward compatible: without `MAGE_X_BUILD_TIMEOUT` set, the only change is a more generous default (3m → 5m) and clearer timeout error messages. No public API signatures changed (`wrapTimeoutError` is unexported).
- Opt-in override lets large cold builds raise the ceiling without patching the tool.

## Notifications
- @mrz1836