### PR TITLE
[Test] Capture and never silently swallow build/process failures

### DIFF
--- a/pkg/mage/ci_runner.go
+++ b/pkg/mage/ci_runner.go
@@ -237,8 +237,16 @@ func (r *ciRunner) runTestWithCI(ctx context.Context, name string, args ...strin
 	// Wait for command to complete
 	cmdErr := cmd.Wait()
 
-	// Collect results
-	r.collectResults()
+	// Collect results, carrying the real process exit code alongside the parsed
+	// test counts. This is the ground-truth signal used to fall back to an error
+	// status when the exit code is non-zero but no failures were parsed - e.g. a
+	// go test output shape the streaming parser doesn't (yet) recognize - instead
+	// of silently reporting a passed run.
+	exitCode := 0
+	if cmd.ProcessState != nil {
+		exitCode = cmd.ProcessState.ExitCode()
+	}
+	r.collectResults(exitCode)
 
 	// Note: Failures are reported in GenerateReport() to avoid duplicates
 	// when tests run multiple times (e.g., with different build tags)
@@ -270,8 +278,10 @@ func (r *ciRunner) processOutput(stdout io.Reader) (retErr error) {
 	return r.parser.Parse(tee)
 }
 
-// collectResults gathers test results from parser
-func (r *ciRunner) collectResults() {
+// collectResults gathers test results from parser. exitCode is the real `go
+// test` process exit code, used as a fallback status signal independent of
+// whatever the streaming parser did or didn't recognize in the output.
+func (r *ciRunner) collectResults(exitCode int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -279,10 +289,16 @@ func (r *ciRunner) collectResults() {
 	uniqueTotal := r.parser.GetUniqueTestCount()
 	failures := r.parser.GetFailures()
 
-	// Determine status
+	// Determine status. A non-zero exit code with zero parsed failures means the
+	// process failed for a reason the parser doesn't attribute to any package or
+	// test - e.g. a future go test output shape it doesn't yet recognize - so
+	// report it as an error rather than silently reporting a passed run.
 	status := TestStatusPassed
-	if failed > 0 {
+	switch {
+	case failed > 0:
 		status = TestStatusFailed
+	case exitCode != 0:
+		status = TestStatusError
 	}
 
 	duration := time.Since(r.startTime)
@@ -296,6 +312,7 @@ func (r *ciRunner) collectResults() {
 			Failed:      len(failures), // Use deduplicated count, not raw count which includes parent tests
 			Skipped:     skipped,
 			Duration:    formatDurationForSummary(duration),
+			ExitCode:    exitCode,
 		},
 		Failures:  failures,
 		Timestamp: r.startTime,

--- a/pkg/mage/ci_runner_test.go
+++ b/pkg/mage/ci_runner_test.go
@@ -430,6 +430,75 @@ main.dereference(0x0)
 	})
 }
 
+// TestCollectResults_ExitCodeFallback proves collectResults falls back to an
+// error status when the real process exit code is non-zero but the streaming
+// parser recorded zero failures - the defense-in-depth path for a failure
+// category the parser doesn't (yet) recognize, independent of any specific
+// output shape.
+func TestCollectResults_ExitCodeFallback(t *testing.T) {
+	t.Parallel()
+
+	newRunner := func(t *testing.T) *ciRunner {
+		t.Helper()
+		runner, ok := NewCIRunner(&mockCommandRunner{}, CIRunnerOptions{
+			Mode: DefaultCIMode(),
+		}).(*ciRunner)
+		if !ok {
+			t.Fatal("Failed to create ciRunner")
+		}
+		return runner
+	}
+
+	t.Run("zero exit code with no failures is passed", func(t *testing.T) {
+		t.Parallel()
+		runner := newRunner(t)
+
+		runner.collectResults(0)
+
+		if runner.results.Summary.Status != TestStatusPassed {
+			t.Errorf("Status = %q, want %q", runner.results.Summary.Status, TestStatusPassed)
+		}
+		if runner.results.Summary.ExitCode != 0 {
+			t.Errorf("ExitCode = %d, want 0", runner.results.Summary.ExitCode)
+		}
+	})
+
+	t.Run("non-zero exit code with no parsed failures is error, not passed", func(t *testing.T) {
+		t.Parallel()
+		runner := newRunner(t)
+
+		runner.collectResults(1)
+
+		if runner.results.Summary.Status != TestStatusError {
+			t.Errorf("Status = %q, want %q (a non-zero exit must never be reported as passed)",
+				runner.results.Summary.Status, TestStatusError)
+		}
+		if runner.results.Summary.Failed != 0 {
+			t.Errorf("Failed = %d, want 0 (no test failures were parsed)", runner.results.Summary.Failed)
+		}
+		if runner.results.Summary.ExitCode != 1 {
+			t.Errorf("ExitCode = %d, want 1", runner.results.Summary.ExitCode)
+		}
+	})
+
+	t.Run("parsed failures take precedence over exit code status", func(t *testing.T) {
+		t.Parallel()
+		runner := newRunner(t)
+
+		mustParseLine(t, runner.parser, []byte(`{"Action":"run","Package":"pkg/foo","Test":"TestOne"}`))
+		mustParseLine(t, runner.parser, []byte(`{"Action":"fail","Package":"pkg/foo","Test":"TestOne","Elapsed":0.1}`))
+
+		runner.collectResults(1)
+
+		if runner.results.Summary.Status != TestStatusFailed {
+			t.Errorf("Status = %q, want %q", runner.results.Summary.Status, TestStatusFailed)
+		}
+		if runner.results.Summary.Failed != 1 {
+			t.Errorf("Failed = %d, want 1", runner.results.Summary.Failed)
+		}
+	})
+}
+
 func TestMultiReporter(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/mage/ci_stream_parser.go
+++ b/pkg/mage/ci_stream_parser.go
@@ -17,14 +17,26 @@ import (
 	"sync/atomic"
 )
 
-// TestEvent represents a single event from `go test -json` output
+// TestEvent represents a single event from `go test -json` output.
+//
+// Two distinct event shapes are folded into this one struct. Normal test events
+// use Package/Test with actions run/pass/fail/skip/output. A package that fails
+// to compile instead produces build-output/build-fail events keyed by ImportPath
+// (the package that didn't compile, which may be a transitive dependency), plus a
+// terminal "fail" event on the test package itself with Test empty and
+// FailedBuild set to the ImportPath that broke the build. Without handling
+// ImportPath/FailedBuild, a build failure silently vanishes: no test event is
+// ever emitted for it, so it does not count as a failure even though `go test`
+// itself exits non-zero.
 type TestEvent struct {
-	Time    string  `json:"Time"`
-	Action  string  `json:"Action"`
-	Package string  `json:"Package"`
-	Test    string  `json:"Test"`
-	Elapsed float64 `json:"Elapsed"`
-	Output  string  `json:"Output"`
+	Time        string  `json:"Time"`
+	Action      string  `json:"Action"`
+	Package     string  `json:"Package"`
+	ImportPath  string  `json:"ImportPath"`
+	Test        string  `json:"Test"`
+	Elapsed     float64 `json:"Elapsed"`
+	Output      string  `json:"Output"`
+	FailedBuild string  `json:"FailedBuild"`
 }
 
 // TestEventHandler processes test events from go test -json
@@ -144,10 +156,16 @@ type streamParser struct {
 	passCount     atomic.Int32
 	failCount     atomic.Int32
 	skipCount     atomic.Int32
-	currentTest   map[string]*testState // pkg:test -> state
+	currentTest   map[string]*testState       // pkg:test -> state
+	buildOutput   map[string]*strings.Builder // ImportPath -> accumulated build-output text
 	dedup         bool
 	adaptiveMode  bool // Whether to adapt strategy based on test count
 }
+
+// maxBuildOutputSize caps accumulated build-output text per import path.
+// Compiler/cgo/pkg-config diagnostics are normally a handful of lines; this is
+// a generous safety bound against a pathological, very chatty build failure.
+const maxBuildOutputSize = 64 * 1024
 
 // testState tracks state for a running test
 type testState struct {
@@ -178,6 +196,7 @@ func NewStreamParser(contextLines int, dedup bool) StreamParser {
 		signatures:    make(map[string]bool),
 		uniqueTests:   make(map[uint64]struct{}),
 		currentTest:   make(map[string]*testState),
+		buildOutput:   make(map[string]*strings.Builder),
 		dedup:         dedup,
 		adaptiveMode:  true,
 	}
@@ -206,6 +225,7 @@ func NewStreamParserWithOptions(opts StreamParserOptions) StreamParser {
 		signatures:    make(map[string]bool),
 		uniqueTests:   make(map[uint64]struct{}),
 		currentTest:   make(map[string]*testState),
+		buildOutput:   make(map[string]*strings.Builder),
 		dedup:         opts.Dedup,
 		adaptiveMode:  opts.AdaptiveMode,
 	}
@@ -282,11 +302,26 @@ func (p *streamParser) processEvent(event *TestEvent) {
 	case "pass":
 		p.OnTestPass(event.Package, event.Test, event.Elapsed)
 	case "fail":
-		p.OnTestFail(event.Package, event.Test, event.Elapsed, p.getTestOutput(key))
+		if event.Test == "" && event.FailedBuild != "" {
+			// A package failed to compile rather than any test failing. Without
+			// this branch the event falls into OnTestFail's package-level early
+			// return and vanishes entirely: no test ever ran, so nothing would
+			// otherwise register the failure.
+			p.onBuildFail(event.Package, event.FailedBuild)
+		} else {
+			p.OnTestFail(event.Package, event.Test, event.Elapsed, p.getTestOutput(key))
+		}
 	case "skip":
 		p.OnTestSkip(event.Package, event.Test, event.Elapsed)
 	case "output":
 		p.OnOutput(event.Package, event.Test, event.Output)
+	case "build-output":
+		p.onBuildOutput(event.ImportPath, event.Output)
+	case "build-fail":
+		// Marks the end of a build-output run for ImportPath. The authoritative,
+		// actionable signal is the later "fail" event on the test package itself
+		// (handled above), which is what names the package the rest of the
+		// pipeline reports against, so there is nothing to do here.
 	}
 }
 
@@ -399,6 +434,67 @@ func (p *streamParser) OnTestFail(pkg, test string, elapsed float64, output stri
 	p.mu.Lock()
 	p.failures = append(p.failures, failure)
 	delete(p.currentTest, pkg+":"+test)
+	p.mu.Unlock()
+}
+
+// onBuildOutput accumulates compiler/build diagnostic text for an import path
+// that is failing to build, keyed by ImportPath since these events precede and
+// are not yet associated with the dependent test package that will report them.
+func (p *streamParser) onBuildOutput(importPath, output string) {
+	if importPath == "" {
+		return
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	sb, ok := p.buildOutput[importPath]
+	if !ok {
+		sb = &strings.Builder{}
+		p.buildOutput[importPath] = sb
+	}
+	if sb.Len() >= maxBuildOutputSize {
+		return
+	}
+	sb.WriteString(output)
+}
+
+// onBuildFail records a package-level failure caused by a build error rather
+// than a test failure. pkg is the test package go test was asked to run;
+// failedBuild is the import path that actually failed to compile (pkg itself,
+// for a package with its own compile error, or a transitive dependency such as
+// a cgo package missing a system library). Without this, a build failure never
+// produces a test event and silently doesn't count as a failure anywhere.
+func (p *streamParser) onBuildFail(pkg, failedBuild string) {
+	p.failCount.Add(1)
+
+	p.mu.Lock()
+	output := ""
+	if sb, ok := p.buildOutput[failedBuild]; ok {
+		output = sb.String()
+	}
+	p.mu.Unlock()
+
+	failure := CITestFailure{
+		Package: pkg,
+		Type:    FailureTypeBuild,
+		Output:  output,
+		Error:   extractBuildErrorMessage(failedBuild, output),
+	}
+	failure.Signature = generateSignature(pkg, "", "", 0, FailureTypeBuild)
+
+	if p.dedup && failure.Signature != "" {
+		p.mu.Lock()
+		if p.signatures[failure.Signature] {
+			p.mu.Unlock()
+			return
+		}
+		p.signatures[failure.Signature] = true
+		p.mu.Unlock()
+	}
+
+	p.mu.Lock()
+	p.failures = append(p.failures, failure)
 	p.mu.Unlock()
 }
 
@@ -763,6 +859,29 @@ func extractErrorMessage(output string) string {
 	}
 
 	return "test failed"
+}
+
+// extractBuildErrorMessage extracts a concise, actionable message from
+// accumulated build-output text for failedBuild. The first line of build-output
+// is always a "# <import path>" banner that go build/test emits to mark which
+// package the following diagnostics belong to (see extractErrorMessage's
+// fallback, which would otherwise return that banner verbatim instead of the
+// actual compiler/linker/pkg-config error beneath it).
+func extractBuildErrorMessage(failedBuild, output string) string {
+	banner := "# " + failedBuild
+
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || trimmed == banner || strings.HasPrefix(trimmed, "# ") {
+			continue
+		}
+		if len(trimmed) > 200 {
+			return trimmed[:200] + "..."
+		}
+		return trimmed
+	}
+
+	return fmt.Sprintf("package %s failed to build", failedBuild)
 }
 
 // formatDurationSeconds formats elapsed seconds as duration string

--- a/pkg/mage/ci_stream_parser_test.go
+++ b/pkg/mage/ci_stream_parser_test.go
@@ -225,6 +225,102 @@ func TestStreamParser_Parse(t *testing.T) {
 	})
 }
 
+// TestStreamParser_BuildFailure proves a package that fails to build - rather
+// than any test failing - is captured as a real failure instead of silently
+// vanishing. Before this, "go test" could exit non-zero with zero failures
+// reported: a CGo package whose C library is missing (govips/libvips is a real
+// example) never gets a test event, so GetStats() reported 0 failed even though
+// the run was broken. The event shapes below (ImportPath/build-output/build-fail,
+// then a top-level "fail" with an empty Test and FailedBuild set) are the exact
+// sequence `go test -json` emits for this case.
+func TestStreamParser_BuildFailure(t *testing.T) {
+	t.Parallel()
+
+	t.Run("transitive cgo dependency fails to build", func(t *testing.T) {
+		t.Parallel()
+		parser := NewStreamParser(20, true)
+
+		input := `{"ImportPath":"github.com/davidbyttow/govips/v2/vips","Action":"build-output","Output":"# github.com/davidbyttow/govips/v2/vips\n"}
+{"ImportPath":"github.com/davidbyttow/govips/v2/vips","Action":"build-output","Output":"Package vips was not found in the pkg-config search path.\n"}
+{"ImportPath":"github.com/davidbyttow/govips/v2/vips","Action":"build-fail"}
+{"Action":"fail","Package":"example.com/functions/image-processor","Elapsed":0,"FailedBuild":"github.com/davidbyttow/govips/v2/vips"}`
+
+		if err := parser.Parse(strings.NewReader(input)); err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+
+		total, passed, failed, skipped := parser.GetStats()
+		if failed != 1 {
+			t.Errorf("failed = %d, want 1 (a build failure must count as a failure)", failed)
+		}
+		if total != 0 || passed != 0 || skipped != 0 {
+			t.Errorf("total/passed/skipped = %d/%d/%d, want 0/0/0 (no test ever ran)", total, passed, skipped)
+		}
+
+		failures := parser.GetFailures()
+		if len(failures) != 1 {
+			t.Fatalf("GetFailures() = %d, want 1", len(failures))
+		}
+
+		f := failures[0]
+		if f.Package != "example.com/functions/image-processor" {
+			t.Errorf("Package = %q, want the test package, not the failed dependency", f.Package)
+		}
+		if f.Type != FailureTypeBuild {
+			t.Errorf("Type = %q, want %q", f.Type, FailureTypeBuild)
+		}
+		if f.Error != "Package vips was not found in the pkg-config search path." {
+			t.Errorf("Error = %q, want the real compiler diagnostic, not the '# <import path>' banner", f.Error)
+		}
+		if !strings.Contains(f.Output, "pkg-config search path") {
+			t.Errorf("Output = %q, want it to retain the full build diagnostic", f.Output)
+		}
+	})
+
+	t.Run("package's own source fails to build", func(t *testing.T) {
+		t.Parallel()
+		parser := NewStreamParser(20, true)
+
+		input := `{"ImportPath":"example.com/pkg/broken","Action":"build-output","Output":"# example.com/pkg/broken\n"}
+{"ImportPath":"example.com/pkg/broken","Action":"build-output","Output":"./file.go:10:2: undefined: Foo\n"}
+{"ImportPath":"example.com/pkg/broken","Action":"build-fail"}
+{"Action":"fail","Package":"example.com/pkg/broken","Elapsed":0,"FailedBuild":"example.com/pkg/broken"}`
+
+		if err := parser.Parse(strings.NewReader(input)); err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+
+		failures := parser.GetFailures()
+		if len(failures) != 1 {
+			t.Fatalf("GetFailures() = %d, want 1", len(failures))
+		}
+		if failures[0].Error != "./file.go:10:2: undefined: Foo" {
+			t.Errorf("Error = %q, want the compile error line", failures[0].Error)
+		}
+	})
+
+	t.Run("normal package-level pass/fail bookkeeping is unaffected", func(t *testing.T) {
+		t.Parallel()
+		parser := NewStreamParser(20, true)
+
+		// A package-level "fail" with no FailedBuild is the ordinary aggregate
+		// event go test emits alongside per-test fail events; it must remain a
+		// no-op so it isn't double-counted against the real per-test failure.
+		input := `{"Action":"run","Package":"pkg/foo","Test":"TestOne"}
+{"Action":"fail","Package":"pkg/foo","Test":"TestOne","Elapsed":0.1}
+{"Action":"fail","Package":"pkg/foo","Elapsed":0.1}`
+
+		if err := parser.Parse(strings.NewReader(input)); err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+
+		_, _, failed, _ := parser.GetStats()
+		if failed != 1 {
+			t.Errorf("failed = %d, want 1 (package-level fail without FailedBuild must not add a second failure)", failed)
+		}
+	})
+}
+
 func TestStreamParser_Deduplication(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/mage/ci_types.go
+++ b/pkg/mage/ci_types.go
@@ -100,6 +100,11 @@ type CISummary struct {
 	Skipped           int        `json:"skipped"`
 	DeadlineTolerated int        `json:"deadline_tolerated,omitempty"`
 	Duration          string     `json:"duration"`
+	// ExitCode is the real `go test` process exit code. It is the ground-truth
+	// signal consumers can cross-check against Failed/Status: a non-zero
+	// ExitCode with Failed == 0 means the process failed for a reason nothing
+	// else in this summary attributes to a specific package or test.
+	ExitCode int `json:"exit_code,omitempty"`
 }
 
 // CIMetadata contains execution context information


### PR DESCRIPTION
## What Changed

**Part 1 — recognize the build-failure event shape:**
* `TestEvent` now recognizes the `ImportPath`/`FailedBuild` fields that `go test -json` emits when a package fails to compile, alongside the existing `Package`/`Test` fields used for normal test events.
* A `fail` event with an empty `Test` and `FailedBuild` set is now handled by a new `onBuildFail`, which records a real `CITestFailure` (`Type: FailureTypeBuild`) against the affected test package, with the actual compiler/linker/pkg-config diagnostic captured as `Error`/`Output`.
* `build-output` events are accumulated per `ImportPath` so diagnostic text is available once the terminal `fail` event ties it back to the test package.
* `extractBuildErrorMessage` skips the `# <import path>` banner line `go build`/`test` always emits first, so `Error` surfaces the actual cause (e.g. `Package vips was not found in the pkg-config search path.`) instead of just repeating the import path.
* Added `TestStreamParser_BuildFailure`, covering a transitive cgo dependency failing to build, a package's own source failing to build, and confirming the ordinary package-level pass/fail bookkeeping event (no `FailedBuild`) stays a no-op so it isn't double-counted.

**Part 2 — defense in depth for any other unrecognized failure shape:**
* `CISummary` gains `ExitCode`, the real `go test` process exit code.
* `collectResults` now takes that exit code and falls back to `TestStatusError` whenever it is non-zero and zero failures were parsed — a category of failure nothing else in the summary attributes to a specific package or test. Parsed failures still take precedence when both are present.
* Added `TestCollectResults_ExitCodeFallback`, covering a clean pass, a non-zero exit with nothing parsed (must not report passed), and parsed failures taking precedence over the exit-code fallback.

## Why It Was Necessary

`go test -json` emits a package build failure as a distinct event shape: `build-output`/`build-fail` events keyed by `ImportPath` (the import path that didn't compile — which may be a transitive dependency, not the test package itself), followed by a top-level `fail` event on the test package with `Test` empty and `FailedBuild` set to that import path. The stream parser only understood the normal `Package`/`Test` event shape, so this fell straight into `OnTestFail`'s package-level early return (`if test == "" { return }`) and vanished entirely — no test event is ever produced for a package that fails to build, so it silently did not count as a failure anywhere: not in `GetStats()`, not in the failure list, not in the status/summary that downstream reporting is built from.

In practice this means a broken build — e.g. a cgo package whose system library isn't installed on the runner — can make the overall `go test` process exit non-zero while every CI-facing summary built from this parser's output reports 0 failures and a passed status, with the only trace of the real cause buried in raw, unparsed build-output stream text thousands of lines away from any summary or annotation.

Part 1 fixes that specific event shape. Part 2 closes the same class of gap structurally: even a completely unanticipated future `go test` output shape can no longer silently report as passed, because the real process exit code is now an independent, always-available ground-truth signal woven into the same summary.

## Testing Performed

* `go build ./...`
* `go vet ./...`
* `go test ./pkg/mage/...` (full package, all green)
* `go test ./pkg/mage/... -race` on the affected tests
* `golangci-lint run ./pkg/mage/...` — 0 issues
* `gofumpt -l` — clean
* New tests cover the real event sequence captured from an actual `go test -json` build failure (both a transitive dependency and a package's own compile error), the pre-existing no-`FailedBuild` bookkeeping event, and the exit-code fallback in `collectResults` (clean pass, unattributed non-zero exit, and parsed-failures-take-precedence).

## Impact / Risk

* **Breaking Change**: None. Both parts only add recognition/fallback for cases that previously fell through as false-positive passes; every existing event shape and its handling is unchanged, and `ExitCode` is a new additive field.
* **Risk**: Low. Changes are scoped to the stream parser's event handling, `collectResults`, and one new struct field; no public API removed or changed.
* **CI Impact**: Any project where a package fails to build, or where `go test` exits non-zero for a reason this parser doesn't otherwise attribute to a test, will now correctly show a failed/error status and real diagnostic detail — instead of a misleadingly green "passed" summary alongside a separately-failing exit code that's hard to explain from the reported counts alone.